### PR TITLE
Use base MUI and msp to simplify logic

### DIFF
--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -17,8 +17,16 @@ $UpdaterVersion = $Matches[1]
 if ($key.Count -eq 1) {
    $InstalledVersion = $key[0].DisplayVersion.replace('.', '')
    if ($key[0].DisplayName -notmatch 'MUI') {
-       Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
-       Write-Warning  'This package will replace it with the multi-language (MUI) release.'
+      if ($InstalledVersion -ge $UpdaterVersion) {
+         Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
+         Write-Warning 'This multi-language (MUI) package cannot overwrite it at this time.'
+         Write-Warning "You will need to uninstall $($key[0].DisplayName) first."
+         Throw 'Installation halted.'
+      }
+      else {
+         Write-Warning "The currently installed $($key[0].DisplayName) is a single-language install."
+         Write-Warning  'This package will replace it with the multi-language (MUI) release.'
+      }
    }
    else {
       $MUIinstalled = $true

--- a/package/tools/chocolateyinstall.ps1
+++ b/package/tools/chocolateyinstall.ps1
@@ -183,3 +183,7 @@ else {
       Throw "Installation of $env:ChocolateyPackageName was unsuccessful."
    }
 }
+
+if ($PackageParameters.NoUpdates -or $UpdateMode -lt 2) {
+   Unregister-ScheduledTask 'Adobe Acrobat Update Task' -Confirm:$false -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Adobe Reader DC installer actually uses base MUI and msp Patch to install. Similarly, `chocolateyinstall.ps1` can also use this method, and thus simplify code logic, reduce download size and installation time. However, [the crucial part of this change](https://github.com/msoxzw/chocolatey.adobe-acrobat-reader-dc/blob/0e6880c342dbfe4089d088514b2121344eb7045f/package/tools/chocolateyinstall.ps1#L165) is very small, i.e. `silentArgs = "/sALL /msi PATCH="Path toPatch""`.